### PR TITLE
Fix source-url

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,6 @@
 {
   "name" : "Text::LTSV",
-  "source-url" : "git://github.com/moznion/p6-Text-LTSV",
+  "source-url" : "git://github.com/moznion/p6-Text-LTSV.git",
   "perl" : "v6",
   "build-depends" : [ ],
   "provides" : {


### PR DESCRIPTION
Our current ecosystem builder wants a `.git` at the end of `git://` URLs. This distro is currently listed with a broken repo URL on modules.perl.org
